### PR TITLE
Add ls2 service configuration

### DIFF
--- a/service/dbus/org.webosports.app.filemanager.service.json.prv
+++ b/service/dbus/org.webosports.app.filemanager.service.json.prv
@@ -1,0 +1,14 @@
+{
+	"role": {
+		"allowedNames": ["org.webosports.app.filemanager.service"],
+		"type": "regular",
+		"exeName": "js"
+	},
+	"permissions": [
+		{
+			"inbound": ["*"],
+			"outbound": ["*"],
+			"service": "org.webosports.app.filemanager.service"
+		}
+	]
+}

--- a/service/dbus/org.webosports.app.filemanager.service.json.pub
+++ b/service/dbus/org.webosports.app.filemanager.service.json.pub
@@ -1,0 +1,14 @@
+{
+	"role": {
+		"allowedNames": ["org.webosports.app.filemanager.service"],
+		"type": "regular",
+		"exeName": "js"
+	},
+	"permissions": [
+		{
+			"inbound": ["*"],
+			"outbound": ["*"],
+			"service": "org.webosports.app.filemanager.service"
+		}
+	]
+}

--- a/service/dbus/org.webosports.app.filemanager.service.service.prv
+++ b/service/dbus/org.webosports.app.filemanager.service.service.prv
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=org.webosports.app.filemanager.service
+Exec=/usr/bin/run-js-service -n /usr/palm/services/org.webosports.app.filemanager.service

--- a/service/dbus/org.webosports.app.filemanager.service.service.pub
+++ b/service/dbus/org.webosports.app.filemanager.service.service.pub
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=org.webosports.app.filemanager.service
+Exec=/usr/bin/run-js-service -n /usr/palm/services/org.webosports.app.filemanager.service


### PR DESCRIPTION
- we need service configuration as we're installing the service into the shipped image and
  therefor the app installer doesn't generate them automatically.

Signed-off-by: Simon Busch morphis@gravedo.de
